### PR TITLE
Make Email Confirm Prettier

### DIFF
--- a/assets/email_confirm.php
+++ b/assets/email_confirm.php
@@ -14,10 +14,9 @@
     //Retrieve data from temporary users file if passkey verified
     if ( $result ) {
         if ( $verified ) {
-            echo "Your have already requested for an alias. You will recieve your alias shortly.";
+            echo "Your have already requested for an alias. You will receive your alias shortly.";
         } else {
-            echo "Your E-mail address has been verified. You will recieve your alias shortly.";
-            echo $email;
+            echo "Your E-mail address (".$email.") has been verified. You will receive your alias shortly.";
             copy_data($email);
         }
     } else {


### PR DESCRIPTION
Earlier Email confirmation message for alias request was something like this:
"Your E-mail address has been verified. You will recieve your alias shortly.lokeshhsharma@gmail.com"

It was ugly. It has been altered to display something like this now:
"Your E-mail address (lokeshhsharma@gmail.com) has been verified. You will receive your alias shortly."
which looks prettier and also spelling of 'receive' has been fixed.